### PR TITLE
Bump version to 0.3.0, use version ranges in dependencies and add CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        python: ['3.8', '3.9', '3.10', '3.11']
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v3
+        with:
+          python-version: '${{ matrix.python }}'
+      - name: Install package
+        run: pip3 install .

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/*
 **/pyghthouse.egg-info/*
 dist/*
+venv

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,11 @@ setup(
     description='Python Lighthouse adapter',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=['numpy~=1.21.2', 'websocket-client~=1.2.1', 'msgpack~=1.0.2'],
+    install_requires=[
+        'numpy >= 1.23, < 2',
+        'websocket-client >= 1.6, < 2',
+        'msgpack >= 1.0, < 2',
+    ],
     package_dir={"": ".", "utils": "./utils"},
     python_requires=">=3.8"
 )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name='pyghthouse',
-    version='0.2.1',
+    version='0.3.0',
     packages=find_packages(where='.'),
     url='https://github.com/Musicted/pyghthouse',
     license='MIT',


### PR DESCRIPTION
This should make the package compatible with Python 3.11, while still ensuring that older versions can install the package (the CI workflow should verify this).