### PR TITLE
Drop numpy requirement 

### DIFF
--- a/examples/huecircle.py
+++ b/examples/huecircle.py
@@ -18,7 +18,7 @@ def circle_generator():
                 for y in range(14):
                     rho, phi = cart2pol(x / 28 - 0.5, y / 14 - 0.5)
                     image[y, x, :] = from_hsv((phi + i / 180) % 1.0, 1-rho, i / 90 if i < 91 else 1 - (i - 90) / 90)
-            yield image
+            yield image.tolist()
 
 
 circle = circle_generator()

--- a/examples/noisefill.py
+++ b/examples/noisefill.py
@@ -7,15 +7,15 @@ from pyghthouse import Pyghthouse
 
 def image_gen():
     image = np.zeros((14, 28, 3))
-    yield image
+    yield image.tolist()
     while True:
         for y in range(28):
             for j in range(3):
                 image[0, y, j] = int(random() * 255)
-            yield image
+            yield image.tolist()
         image = np.roll(image, 1, 0)
         image *= 0.85
-        yield image
+        yield image.tolist()
 
 
 g = image_gen()

--- a/examples/rgbfill.py
+++ b/examples/rgbfill.py
@@ -23,6 +23,6 @@ def image_gen():
 g = image_gen()
 
 if __name__ == '__main__':
-    p = Pyghthouse(UNAME, TOKEN, image_callback=g.__next__, frame_rate=10)
+    p = Pyghthouse(UNAME, TOKEN, image_callback=g.__next__, frame_rate=60)
     print("Starting... use CTRL+C to stop.")
     p.start()

--- a/examples/rgbfill.py
+++ b/examples/rgbfill.py
@@ -6,23 +6,23 @@ from pyghthouse import Pyghthouse
 
 def image_gen():
     image = np.zeros((14, 28, 3))
-    yield image
+    yield image.tolist()
     while True:
         for x in range(14):
             for y in range(28):
                 for j in range(3):
                     image[x, y, j] = 255
-                    yield image
+                    yield image.tolist()
         for y in range(28):
             for x in range(14):
                 for j in range(3):
                     image[x, y, j] = 0
-                    yield image
+                    yield image.tolist()
 
 
 g = image_gen()
 
 if __name__ == '__main__':
-    p = Pyghthouse(UNAME, TOKEN, image_callback=g.__next__, frame_rate=60)
+    p = Pyghthouse(UNAME, TOKEN, image_callback=g.__next__, frame_rate=10)
     print("Starting... use CTRL+C to stop.")
     p.start()

--- a/examples/rgbscan.py
+++ b/examples/rgbscan.py
@@ -6,13 +6,13 @@ from pyghthouse import Pyghthouse
 
 def image_gen():
     image = np.zeros((14, 28, 3))
-    yield image
+    yield image.tolist()
     while True:
         for j in range(3):
             for x in range(14):
                 for y in range(28):
                     image[x, y, j] = 255
-                    yield image
+                    yield image.tolist()
                     image[x, y, j] = 0
 
 

--- a/examples/twopoints.py
+++ b/examples/twopoints.py
@@ -55,7 +55,7 @@ class ImageMaker:
                        fill=tuple(from_hsv(self.hue, 1, 1)))
         output = self.img.copy()
         output.thumbnail((28, 14))
-        return np.asarray(output)
+        return np.asarray(output).tolist()
 
 
 if __name__ == '__main__':

--- a/pyghthouse/data/canvas.py
+++ b/pyghthouse/data/canvas.py
@@ -1,7 +1,7 @@
 from typing import Union, Iterable
-# import numpy as np
-class PyghthouseCanvas:
 
+
+class PyghthouseCanvas:
     VALID_IMAGE_TYPE = Union[Iterable, int]
     IMAGE_SHAPE = (14, 28, 3)
 
@@ -15,8 +15,9 @@ class PyghthouseCanvas:
     """
     Flattens the list. Works for nested lists too.
     """
-    def flatten_list(self,element):
-        if(type(element)==list):
+
+    def flatten_list(self, element):
+        if type(element) == list:
             result = []
             for element in element:
                 result.extend(self.flatten_list(element))
@@ -24,13 +25,13 @@ class PyghthouseCanvas:
         else:
             return [element]
 
-
     """
     Creates a nested list in the shape of IMAGE_SHAPE. 
     number_cb: function
         A function that returns an integer (or to integer castable) element.
     """
-    def init_image_array(self,number_cb=lambda: 0):
+
+    def init_image_array(self, number_cb=lambda: 0):
         list = []
         for x in range(self.IMAGE_SHAPE[0]):
             list_y = []
@@ -49,14 +50,15 @@ class PyghthouseCanvas:
         If list provided, it must contain exactly as many elements as the image needs values,
             but it may be nested in any way.
     """
-    def new_image_to_image_array(self,new_image: VALID_IMAGE_TYPE) -> list:
-        if(type(new_image)==int):
-            if(0<=new_image<=255):
+
+    def new_image_to_image_array(self, new_image: VALID_IMAGE_TYPE) -> list[int]:
+        if isinstance(new_image, int):
+            if 0 <= new_image <= 255:
                 return self.init_image_array(lambda: new_image)
             else:
                 raise ValueError("Color must be 0<=color<=255")
-            
-        if(type(new_image)==list):
+
+        if isinstance(new_image, list):
             try:
                 flat = self.flatten_list(new_image)
                 result = self.init_image_array(lambda: int(flat.pop(0)))
@@ -70,18 +72,22 @@ class PyghthouseCanvas:
     """
     Sets the new image.
     """
+
     def set_image(self, new_image: VALID_IMAGE_TYPE) -> list:
         try:
             self.image = self.new_image_to_image_array(new_image)
         except ValueError as e:
-            raise ValueError(f"{e}. Most likely, your image does not have the correct dimensions.") from None
+            raise ValueError(
+                f"{e}. Most likely, your image does not have the correct dimensions."
+            ) from None
 
         return self.image
 
     """
     Transforms the image to byte values.
     """
-    def get_image_bytes(self)->bytes:
+
+    def get_image_bytes(self) -> bytes:
         b_array = bytearray()
         for x in range(self.IMAGE_SHAPE[0]):
             for y in range(self.IMAGE_SHAPE[1]):

--- a/pyghthouse/data/canvas.py
+++ b/pyghthouse/data/canvas.py
@@ -40,22 +40,7 @@ class PyghthouseCanvas:
                 return self.init_image_array(lambda: new_image)
             else:
                 raise ValueError("Color must be 0<=color<=255")
-        # if(type(new_image)==list):
-        #     if (len(new_image)!=self.IMAGE_SHAPE[0]):
-        #                 raise ValueError("Invalid shape")
-        #     for x in range(len(new_image)):
-        #         if (len(new_image[x])!=self.IMAGE_SHAPE[1]):
-        #                 raise ValueError("Invalid shape.")
-        #         for y in range(len(new_image[x])):
-        #             if (len(new_image[x][y])!=self.IMAGE_SHAPE[2]):
-        #                 raise ValueError("Invalid shape.")
-        #             for rgb in range(len(new_image[x][y])):
-        #                 if(not(isinstance(new_image[x][y][rgb],int))):
-        #                     # try to parse all values as int here
-        #                     new_image[x][y][rgb] = int(new_image[x][y][rgb])
-        #                 if(not (0<=new_image[x][y][rgb]<=255)):
-        #                     raise ValueError(f"Pixel at {x},{y} has invalid color code.")
-        #     return new_image
+            
         if(type(new_image)==list):
             try:
                 flat = self.flatten_list(new_image)

--- a/pyghthouse/data/canvas.py
+++ b/pyghthouse/data/canvas.py
@@ -1,26 +1,84 @@
 from typing import Union, Iterable
-import numpy as np
-
-
+# import numpy as np
 class PyghthouseCanvas:
 
-    VALID_IMAGE_TYPE = Union[np.ndarray, Iterable, int]
+    VALID_IMAGE_TYPE = Union[Iterable, int]
     IMAGE_SHAPE = (14, 28, 3)
 
     def __init__(self, initial_image=None):
-        self.image = np.zeros(self.IMAGE_SHAPE, dtype=np.ubyte)
+        self.image = self.init_image_array()
         if initial_image is None:
-            self.image[:, :, 0] = 255
+            self.image[:][:][0] = 255
         else:
             self.set_image(initial_image)
 
-    def set_image(self, new_image: VALID_IMAGE_TYPE) -> np.array:
+    def flatten_list(self,element):
+        if(type(element)==list):
+            result = []
+            for element in element:
+                result.extend(self.flatten_list(element))
+            return result
+        else:
+            return [element]
+
+
+    def init_image_array(self,number_cb=lambda: 0):
+        list = []
+        for x in range(self.IMAGE_SHAPE[0]):
+            list_y = []
+            for y in range(self.IMAGE_SHAPE[1]):
+                list_rgb = []
+                for rgb in range(self.IMAGE_SHAPE[2]):
+                    list_rgb.append(int(number_cb()))
+                list_y.append(list_rgb)
+            list.append(list_y)
+        return list
+    
+    def new_image_to_image_array(self,new_image: VALID_IMAGE_TYPE) -> list:
+        if(type(new_image)==int):
+            if(0<=new_image<=255):
+                return self.init_image_array(lambda: new_image)
+            else:
+                raise ValueError("Color must be 0<=color<=255")
+        # if(type(new_image)==list):
+        #     if (len(new_image)!=self.IMAGE_SHAPE[0]):
+        #                 raise ValueError("Invalid shape")
+        #     for x in range(len(new_image)):
+        #         if (len(new_image[x])!=self.IMAGE_SHAPE[1]):
+        #                 raise ValueError("Invalid shape.")
+        #         for y in range(len(new_image[x])):
+        #             if (len(new_image[x][y])!=self.IMAGE_SHAPE[2]):
+        #                 raise ValueError("Invalid shape.")
+        #             for rgb in range(len(new_image[x][y])):
+        #                 if(not(isinstance(new_image[x][y][rgb],int))):
+        #                     # try to parse all values as int here
+        #                     new_image[x][y][rgb] = int(new_image[x][y][rgb])
+        #                 if(not (0<=new_image[x][y][rgb]<=255)):
+        #                     raise ValueError(f"Pixel at {x},{y} has invalid color code.")
+        #     return new_image
+        if(type(new_image)==list):
+            try:
+                flat = self.flatten_list(new_image)
+                result = self.init_image_array(lambda: int(flat.pop(0)))
+                if len(flat) != 0:
+                    raise ValueError("Input too large")
+                return result
+            except IndexError:
+                raise ValueError("Wrong length of Iterable")
+        raise ValueError("Invalid input. Must be int or list")
+
+    def set_image(self, new_image: VALID_IMAGE_TYPE) -> list:
         try:
-            self.image[:] = np.asarray(new_image).reshape(self.IMAGE_SHAPE)
+            self.image = self.new_image_to_image_array(new_image)
         except ValueError as e:
             raise ValueError(f"{e}. Most likely, your image does not have the correct dimensions.") from None
 
         return self.image
 
-    def get_image_bytes(self):
-        return self.image.tobytes()
+    def get_image_bytes(self)->bytes:
+        b_array = bytearray()
+        for x in range(self.IMAGE_SHAPE[0]):
+            for y in range(self.IMAGE_SHAPE[1]):
+                for rgb in range(self.IMAGE_SHAPE[2]):
+                    b_array.append(self.image[x][y][rgb])
+        return b_array

--- a/pyghthouse/data/canvas.py
+++ b/pyghthouse/data/canvas.py
@@ -1,12 +1,12 @@
-from typing import Union, Iterable
+from typing import Any, Union, Iterable, Callable
 
 
 class PyghthouseCanvas:
-    VALID_IMAGE_TYPE = Union[Iterable, int]
+    VALID_IMAGE_TYPE = Union[Iterable[Any], int]
     IMAGE_SHAPE = (14, 28, 3)
 
-    def __init__(self, initial_image=None):
-        self.image = self.init_image_array()
+    def __init__(self, initial_image: VALID_IMAGE_TYPE | None = None):
+        self.image: list[list[list[int]]] = self.init_image_array()
         if initial_image is None:
             self.image[:][:][0] = 255
         else:
@@ -16,11 +16,11 @@ class PyghthouseCanvas:
     Flattens the list. Works for nested lists too.
     """
 
-    def flatten_list(self, element):
-        if type(element) == list:
-            result = []
-            for element in element:
-                result.extend(self.flatten_list(element))
+    def flatten_list(self, element: list[Any] | Any) -> list[Any]:
+        if isinstance(element, list):
+            result: list[Any] = []
+            for elem in element:
+                result.extend(self.flatten_list(elem))
             return result
         else:
             return [element]
@@ -31,17 +31,19 @@ class PyghthouseCanvas:
         A function that returns an integer (or to integer castable) element.
     """
 
-    def init_image_array(self, number_cb=lambda: 0):
-        list = []
-        for x in range(self.IMAGE_SHAPE[0]):
-            list_y = []
-            for y in range(self.IMAGE_SHAPE[1]):
-                list_rgb = []
-                for rgb in range(self.IMAGE_SHAPE[2]):
+    def init_image_array(
+        self, number_cb: Callable[[], Any] = lambda: 0
+    ) -> list[list[list[int]]]:
+        list_total: list[list[list[int]]] = []
+        for _ in range(self.IMAGE_SHAPE[0]):
+            list_y: list[list[int]] = []
+            for _ in range(self.IMAGE_SHAPE[1]):
+                list_rgb: list[int] = []
+                for _ in range(self.IMAGE_SHAPE[2]):
                     list_rgb.append(int(number_cb()))
                 list_y.append(list_rgb)
-            list.append(list_y)
-        return list
+            list_total.append(list_y)
+        return list_total
 
     """
     Parses user input to image data.
@@ -51,7 +53,7 @@ class PyghthouseCanvas:
             but it may be nested in any way.
     """
 
-    def new_image_to_image_array(self, new_image: VALID_IMAGE_TYPE) -> list[int]:
+    def new_image_to_image_array(self, new_image: VALID_IMAGE_TYPE) -> list[Any]:
         if isinstance(new_image, int):
             if 0 <= new_image <= 255:
                 return self.init_image_array(lambda: new_image)
@@ -73,7 +75,7 @@ class PyghthouseCanvas:
     Sets the new image.
     """
 
-    def set_image(self, new_image: VALID_IMAGE_TYPE) -> list:
+    def set_image(self, new_image: VALID_IMAGE_TYPE) -> list[list[list[int]]]:
         try:
             self.image = self.new_image_to_image_array(new_image)
         except ValueError as e:
@@ -87,7 +89,7 @@ class PyghthouseCanvas:
     Transforms the image to byte values.
     """
 
-    def get_image_bytes(self) -> bytes:
+    def get_image_bytes(self) -> bytearray:
         b_array = bytearray()
         for x in range(self.IMAGE_SHAPE[0]):
             for y in range(self.IMAGE_SHAPE[1]):

--- a/pyghthouse/data/canvas.py
+++ b/pyghthouse/data/canvas.py
@@ -12,6 +12,9 @@ class PyghthouseCanvas:
         else:
             self.set_image(initial_image)
 
+    """
+    Flattens the list. Works for nested lists too.
+    """
     def flatten_list(self,element):
         if(type(element)==list):
             result = []
@@ -22,6 +25,11 @@ class PyghthouseCanvas:
             return [element]
 
 
+    """
+    Creates a nested list in the shape of IMAGE_SHAPE. 
+    number_cb: function
+        A function that returns an integer (or to integer castable) element.
+    """
     def init_image_array(self,number_cb=lambda: 0):
         list = []
         for x in range(self.IMAGE_SHAPE[0]):
@@ -33,7 +41,14 @@ class PyghthouseCanvas:
                 list_y.append(list_rgb)
             list.append(list_y)
         return list
-    
+
+    """
+    Parses user input to image data.
+    new_image: int | list
+        If int provided, sets all values to this number. Must be between 0 and 255.
+        If list provided, it must contain exactly as many elements as the image needs values,
+            but it may be nested in any way.
+    """
     def new_image_to_image_array(self,new_image: VALID_IMAGE_TYPE) -> list:
         if(type(new_image)==int):
             if(0<=new_image<=255):
@@ -52,6 +67,9 @@ class PyghthouseCanvas:
                 raise ValueError("Wrong length of Iterable")
         raise ValueError("Invalid input. Must be int or list")
 
+    """
+    Sets the new image.
+    """
     def set_image(self, new_image: VALID_IMAGE_TYPE) -> list:
         try:
             self.image = self.new_image_to_image_array(new_image)
@@ -60,6 +78,9 @@ class PyghthouseCanvas:
 
         return self.image
 
+    """
+    Transforms the image to byte values.
+    """
     def get_image_bytes(self)->bytes:
         b_array = bytearray()
         for x in range(self.IMAGE_SHAPE[0]):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     description='Python Lighthouse adapter',
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=['numpy~=1.21.2', 'websocket-client~=1.2.1', 'msgpack~=1.0.2'],
+    install_requires=['websocket-client~=1.2.1', 'msgpack~=1.0.2'],
     package_dir={"": ".", "utils": "./utils"},
     python_requires=">=3.8"
 )


### PR DESCRIPTION
I refactored the code to do what the numpy functions did with builtin functions.
Numpy accepted anything that could somehow be interpreted as an array, now the `set_image` Function really needs an python-list or int, although the list can be nested in any way.

The given examples all work with this changes, after refactoring them to call set_image with python lists instead of numpy-arrays.