### PR TITLE
Fixes termination issues regarding #4

### DIFF
--- a/pyghthouse/connection/wsconnector.py
+++ b/pyghthouse/connection/wsconnector.py
@@ -39,11 +39,9 @@ class WSConnector:
         self.ws = WebSocketApp(self.address,
                                on_message=None if self.on_msg is None else self._handle_msg,
                                on_open=self._ready, on_error=self._fail)
-        self.lock.acquire()
+        self.lock.acquire() # wait for connection to be established
         kwargs = {"sslopt": {"cert_reqs": CERT_NONE}} if self.ignore_ssl_cert else None
         Thread(target=self.ws.run_forever, kwargs=kwargs).start()
-        self.lock.acquire() # wait for connection to be established
-        self.lock.release()
 
     def _fail(self, ws, err):
         self.lock.release()

--- a/pyghthouse/connection/wsconnector.py
+++ b/pyghthouse/connection/wsconnector.py
@@ -48,8 +48,8 @@ class WSConnector:
         self.lock.acquire() # wait for connection to be established
         self.__connection_state = ConnectionState.CONNECTING
         kwargs = {"sslopt": {"cert_reqs": CERT_NONE}} if self.ignore_ssl_cert else None
-        Thread(target=self.ws.run_forever, kwargs=kwargs).start()
-        
+        Thread(target=self.ws.run_forever, name="Websocket Thread", kwargs=kwargs).start()
+
 
     def _fail(self, ws, err):
         self.__connection_state = ConnectionState.FAILED

--- a/pyghthouse/ph.py
+++ b/pyghthouse/ph.py
@@ -212,7 +212,14 @@ class Pyghthouse:
             self.connect()
         self.stop()
         self.msg_handler.reset()
-        while not self.connector.connection_state==ConnectionState.CONNECTED:
+        while True:
+            state=self.connector.connection_state
+            if state==ConnectionState.CONNECTED:
+                # Connected
+                break
+            elif state==ConnectionState.FAILED:
+                # Connection failed
+                raise ConnectionError("Failed to connect")
             sleep(100)
         self.ph_thread = self.PHThread(self)
         self.ph_thread.start()

--- a/pyghthouse/ph.py
+++ b/pyghthouse/ph.py
@@ -166,7 +166,7 @@ class Pyghthouse:
     class PHThread(Thread):
 
         def __init__(self, parent):
-            super().__init__()
+            super().__init__(name = "PHThread")
             self.parent = parent
             self._stop_event = Event()
 

--- a/pyghthouse/ph.py
+++ b/pyghthouse/ph.py
@@ -6,7 +6,7 @@ from signal import signal, SIGINT
 import numpy as np
 
 from pyghthouse.data.canvas import PyghthouseCanvas
-from pyghthouse.connection.wsconnector import WSConnector
+from pyghthouse.connection.wsconnector import WSConnector,ConnectionState
 
 
 class VerbosityLevel(Enum):
@@ -208,10 +208,12 @@ class Pyghthouse:
         self.connector.start()
 
     def start(self):
-        if not self.connector.running:
+        if not self.connector.connection_state==ConnectionState.CONNECTED:
             self.connect()
         self.stop()
         self.msg_handler.reset()
+        while not self.connector.connection_state==ConnectionState.CONNECTED:
+            sleep(100)
         self.ph_thread = self.PHThread(self)
         self.ph_thread.start()
 


### PR DESCRIPTION
One of the main issues was a timing issue between initializing the connection and already accepting send requests. Antoher option would be to block accepting send requests until the connection has status connected.

I am not yet sure if this the final solution but Termination via KeyboardInterupt looks reliable for now.